### PR TITLE
Reverted the default backend for StencilMatrix from PSYDAC_BACKENDS['…

### DIFF
--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -945,10 +945,9 @@ class StencilMatrix(LinearOperator):
         self._transpose_args = self._prepare_transpose_args()
         self._transpose_func = kernels['transpose'][self._ndim]
 
-        if backend is None:
-            backend = PSYDAC_BACKENDS.get(os.environ.get('PSYDAC_BACKEND')) or PSYDAC_BACKENDS['python']
-        if backend:
-            self.set_backend(backend, precompiled)
+        # if backend is None:
+        #     backend = PSYDAC_BACKENDS.get(os.environ.get('PSYDAC_BACKEND')) or PSYDAC_BACKENDS['python']
+        self.set_backend(backend, precompiled)
 
     #--------------------------------------
     # Abstract interface
@@ -2281,7 +2280,7 @@ class StencilInterfaceMatrix(LinearOperator):
         self._transpose_func = kernels['interface_transpose'][self._ndim]
 
         if backend is None:
-            backend = PSYDAC_BACKENDS.get(os.environ.get('PSYDAC_BACKEND'))# or PSYDAC_BACKENDS['python']
+            backend = PSYDAC_BACKENDS.get(os.environ.get('PSYDAC_BACKEND'))
 
         if backend:
             self.set_backend(backend)


### PR DESCRIPTION
…python'] to None.