### PR TITLE
Removed the <3.12 requirement for python

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,8 +17,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         # TODO: Make sure that struphy works with python > 3.11, keep the lower bound to 3.10
-        #python-version: [ 3.9, '3.10', '3.11', '3.12' ]
-        python-version: [ '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         isMerge:
           - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
         #exclude:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -209,10 +209,10 @@ jobs:
           echo "PSYDAC_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "STRUPHY_DIR=$GITHUB_WORKSPACE/struphy" >> $GITHUB_ENV
 
-      - name: Clone struphy from GitLab (struphy-with-psydac-devel branch)
+      - name: Clone struphy from GitLab (devel branch)
         run: |
           # TODO: Use the struphy devel branch here when it's ready
-          git clone --branch struphy-with-psydac-devel https://gitlab.mpcdf.mpg.de/struphy/struphy.git $STRUPHY_DIR
+          git clone --branch devel https://gitlab.mpcdf.mpg.de/struphy/struphy.git $STRUPHY_DIR
       
       - name: Install struphy
         working-directory: ${{ env.STRUPHY_DIR }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name            = "psydac"
 version         = "0.1"
 description     = "Python package for isogeometric analysis (IGA)"
 readme          = "README.md"
-requires-python = ">= 3.10, < 3.12"
+requires-python = ">= 3.10"
 license         = {file = "LICENSE"}
 authors         = [
     {name = "Psydac development team", email = "psydac@googlegroups.com"}


### PR DESCRIPTION
**Changes**

* Removed the `<3.12` requirement in the `pyproject.toml`.
* Run the tests with python 3.9, 3.10, 3.11, and 3.12