### PR TITLE
Improved psydac-accelerate by also cleaning up the old files

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -117,7 +117,7 @@ jobs:
       - if: steps.cache-petsc.outputs.cache-hit != 'true'
         name: Download a specific release of PETSc
         run: |
-          git clone --depth 1 --branch v3.21.4 https://gitlab.com/petsc/petsc.git
+          git clone --depth 1 --branch v3.22.2 https://gitlab.com/petsc/petsc.git
 
       - if: steps.cache-petsc.outputs.cache-hit != 'true'
         name: Install PETSc with complex support

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           export PETSC_DIR=$(pwd)
           export PETSC_ARCH=petsc-cmplx
-          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --download-fblaslapack=1
           make all
           echo "PETSC_DIR=$PETSC_DIR" > petsc.env
           echo "PETSC_ARCH=$PETSC_ARCH" >> petsc.env

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Although Psydac provides several iterative linear solvers which work with our na
 In order to use these additional feature, PETSc and petsc4py must be installed as follows.
 First, we download the latest release of PETSc from its [official Git repository](https://gitlab.com/petsc/petsc):
 ```sh
-git clone --depth 1 --branch v3.21.4 https://gitlab.com/petsc/petsc.git
+git clone --depth 1 --branch v3.22.2 https://gitlab.com/petsc/petsc.git
 ```
 Next, we specify a configuration for complex numbers, and install PETSc in a local directory:
 ```sh

--- a/psydac/accelerate/accelerate.py
+++ b/psydac/accelerate/accelerate.py
@@ -1,53 +1,111 @@
-
 import argparse
+import logging
 import os
-from subprocess import run as sub_run
-import shutil
+import sys
+from shutil import which, rmtree
+from subprocess import run as sub_run, PIPE, STDOUT  # nosec B404
 
 import psydac
 
-def main():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="Accelerate all computational kernels in Psydac using Pyccel"
+
+def configure_logging(level=logging.INFO):
+    """
+    Configure global logging settings.
+    """
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s: %(message)s",
+        stream=sys.stdout
     )
 
-    # Add Argument --language at the pyccel command
-    parser.add_argument('--language',
-                        type=str,
-                        default='fortran',
-                        choices=['fortran', 'c'],
-                        action='store',
-                        dest='language',
-                        help='Language used to pyccelize all the _kernels files'
-                        )
 
-    # Add flag --openmp at the pyccel command
-    parser.add_argument('--openmp',
-                        default=False,
-                        action='store_true',
-                        dest='openmp',
-                        help="Use OpenMP multithreading in generated code."
-                        )
+def pyccelize_files(root_path: str, language: str = 'fortran', openmp: bool = False):
+    """
+    Recursively pyccelize all files ending with '_kernels.py' in the given root path.
 
-    # Read input arguments
-    args = parser.parse_args()
+    Parameters
+    ----------
+    root_path : str
+        Path to the Psydac source directory.
+    language : str, optional
+        Programming language for pyccel generated code ('fortran' or 'c'), by default 'fortran'.
+    openmp : bool, optional
+        Whether to enable OpenMP multithreading, by default False.
+    """
+    pyccel_path = which('pyccel')
+    if pyccel_path is None:
+        logging.error("`pyccel` not found in PATH. Please ensure it is installed and accessible.")
+        return
 
-    # get the absolute path to the psydac directory
-    psydac_path = os.path.abspath(os.path.dirname(psydac.__path__[0]))
-
-    # Define all the parameters of the command in the parameters array
-    parameters = ['--language', args.language]
-
-    # check if the flag --openmp is passed and add it to the argument if it's the case
-    if args.openmp:
+    parameters = ['--language', language]
+    if openmp:
         parameters.append('--openmp')
 
-    # search in psydac/psydac folder all the files ending with the tag _kernels.py
-    for path, subdirs, files in os.walk(psydac_path):
+    for root, _, files in os.walk(root_path):
         for name in files:
             if name.endswith('_kernels.py'):
-                command = [shutil.which('pyccel'), os.path.join(path, name), *parameters]
-                print('  Pyccelize file: ' + os.path.join(path, name))
-                print(' '.join(command))
-                sub_run(command, shell=False)
+                file_path = os.path.join(root, name)
+                logging.info(f"Pyccelizing: {file_path}")
+                command = [pyccel_path, file_path] + parameters
+                logging.info(f"Running command: {' '.join(command)}")
+
+                try:
+                    result = sub_run(command, stdout=PIPE, stderr=STDOUT, text=True, shell=False, check=True)  # nosec B603
+                    if result.stdout.strip():
+                        logging.info(result.stdout.strip())
+                except Exception as e:
+                    logging.error(f"Failed to pyccelize {file_path}: {e}")
+
+
+def cleanup_files(root_path: str):
+    """
+    Remove unnecessary build artifacts, such as `__pyccel__` directories and `.lock_acquisition.lock` files.
+    """
+    # Remove __pyccel__ directories
+    for root, dirs, _ in os.walk(root_path):
+        for dirname in dirs:
+            if dirname == '__pyccel__':
+                dir_to_remove = os.path.join(root, dirname)
+                logging.info(f"Removing directory: {dir_to_remove}")
+                rmtree(dir_to_remove)
+
+    # Remove .lock_acquisition.lock files
+    for root, _, files in os.walk(root_path):
+        for filename in files:
+            if filename == '.lock_acquisition.lock':
+                file_to_remove = os.path.join(root, filename)
+                logging.info(f"Removing lock file: {file_to_remove}")
+                os.remove(file_to_remove)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pyccelize Psydac kernel files and optionally clean up build artifacts.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('--language', type=str, default='fortran', choices=['fortran', 'c'],
+                        help="Language used to pyccelize kernel files.")
+    parser.add_argument('--openmp', action='store_true',
+                        help="Use OpenMP multithreading in generated code.")
+    parser.add_argument('--cleanup', action='store_true',
+                        help="Remove unnecessary files and directories after pyccelizing.")
+
+    args = parser.parse_args()
+
+    # Configure logging
+    configure_logging(logging.INFO)
+
+    # Get the absolute path to the psydac directory
+    psydac_path = os.path.abspath(os.path.dirname(psydac.__path__[0]))
+
+    # Pyccelize kernel files
+    pyccelize_files(psydac_path, language=args.language, openmp=args.openmp)
+
+    # Cleanup if requested
+    if args.cleanup:
+        print('Cleanup')
+        cleanup_files(psydac_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/psydac/accelerate/accelerate.py
+++ b/psydac/accelerate/accelerate.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import os
 import sys
 from shutil import which, rmtree
@@ -8,17 +7,6 @@ from subprocess import run as sub_run, PIPE, STDOUT  # nosec B404
 import psydac
 # Get the absolute path to the psydac directory
 psydac_path = os.path.abspath(os.path.dirname(psydac.__path__[0]))
-
-def configure_logging(level=logging.INFO):
-    """
-    Configure global logging settings.
-    """
-    logging.basicConfig(
-        level=level,
-        format="%(levelname)s: %(message)s",
-        stream=sys.stdout
-    )
-
 
 def pyccelize_files(root_path: str, language: str = 'fortran', openmp: bool = False):
     """
@@ -34,10 +22,10 @@ def pyccelize_files(root_path: str, language: str = 'fortran', openmp: bool = Fa
         Whether to enable OpenMP multithreading, by default False.
     """
     if language not in ['c', 'fortran']:
-        logging.error(f"Unsupported language: {language}")
+        print(f"Unsupported language: {language}")
     pyccel_path = which('pyccel')
     if pyccel_path is None:
-        logging.error("`pyccel` not found in PATH. Please ensure it is installed and accessible.")
+        print("`pyccel` not found in PATH. Please ensure it is installed and accessible.")
         return
 
     parameters = ['--language', language]
@@ -74,19 +62,19 @@ def pyccelize_files(root_path: str, language: str = 'fortran', openmp: bool = Fa
                     generated_file = os.path.join(root, subdir, name[:-3] + '.c')
 
                 if os.path.isfile(generated_file):
-                    logging.info(f"Skipping {file_path}: Already pyccelized to {generated_file}")
+                    print(f"Skipping {file_path}: Already pyccelized to {generated_file}")
                     continue  # Skip already pyccelized files
 
-                # logging.info(f"Pyccelizing: {file_path}")
+                # print(f"Pyccelizing: {file_path}")
                 command = [pyccel_path, file_path] + parameters
-                logging.info(f"Running command: {' '.join(command)}")
+                print(f"Running command: {' '.join(command)}")
 
                 try:
                     result = sub_run(command, stdout=PIPE, stderr=STDOUT, text=True, shell=False, check=True)  # nosec B603
                     if result.stdout.strip():
-                        logging.info(result.stdout.strip())
+                        print(result.stdout.strip())
                 except Exception as e:
-                    logging.error(f"Failed to pyccelize {file_path}: {e}")
+                    print(f"Failed to pyccelize {file_path}: {e}")
 
 def cleanup_files(root_path: str):
     """
@@ -97,7 +85,7 @@ def cleanup_files(root_path: str):
         for dirname in dirs:
             if dirname == '__pyccel__':
                 dir_to_remove = os.path.join(root, dirname)
-                logging.info(f"Removing directory: {dir_to_remove}")
+                print(f"Removing directory: {dir_to_remove}")
                 rmtree(dir_to_remove)
 
     # Remove .lock_acquisition.lock files
@@ -105,7 +93,7 @@ def cleanup_files(root_path: str):
         for filename in files:
             if filename == '.lock_acquisition.lock':
                 file_to_remove = os.path.join(root, filename)
-                logging.info(f"Removing lock file: {file_to_remove}")
+                print(f"Removing lock file: {file_to_remove}")
                 os.remove(file_to_remove)
 
 
@@ -122,9 +110,6 @@ def main():
                         help="Remove unnecessary files and directories after pyccelizing.")
 
     args = parser.parse_args()
-
-    # Configure logging
-    configure_logging(logging.INFO)
 
     # Cleanup if requested
     if args.cleanup:

--- a/psydac/accelerate/accelerate.py
+++ b/psydac/accelerate/accelerate.py
@@ -114,7 +114,7 @@ def main():
         description="Pyccelize Psydac kernel files and optionally clean up build artifacts.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument('--language', type=str, default='fortran', choices=['fortran', 'c'],
+    parser.add_argument('--language', type=str, default='c', choices=['fortran', 'c'],
                         help="Language used to pyccelize kernel files.")
     parser.add_argument('--openmp', action='store_true',
                         help="Use OpenMP multithreading in generated code.")
@@ -126,13 +126,13 @@ def main():
     # Configure logging
     configure_logging(logging.INFO)
 
-    # Pyccelize kernel files
-    pyccelize_files(psydac_path, language=args.language, openmp=args.openmp)
-
     # Cleanup if requested
     if args.cleanup:
         print('Cleanup')
         cleanup_files(psydac_path)
+    else:
+        # Pyccelize kernel files
+        pyccelize_files(psydac_path, language=args.language, openmp=args.openmp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
You can compile psydac kernels with

```
psydac-accelerate --language c
psydac-accelerate --language fortran
```

Now, the temporary and unneccesary files are also cleaned up when compiling with the opposite language.

Manual cleanup can be initiated with

```
psydac-accelerate --cleanup
```