### PR TITLE
change to feectools, bump version to 0.1.2

### DIFF
--- a/.github/actions/install/psydac-in-container/action.yml
+++ b/.github/actions/install/psydac-in-container/action.yml
@@ -22,6 +22,8 @@ runs:
           ls / -a
           which python3
           ls -a
+          mkdir for_cloning
+          cd for_cloning
           git clone https://github.com/struphy-hub/feectools.git
           cd feectools
           echo ${GIT_BRANCH_NAME}

--- a/.github/actions/install/psydac-in-container/action.yml
+++ b/.github/actions/install/psydac-in-container/action.yml
@@ -31,4 +31,4 @@ runs:
           pip show feectools
           psydac-accelerate --cleanup --yes
           pip uninstall feectools -y
-          python3 -m pip install . --force-reinstall --no-cache-dir
+          python3 -m pip install .

--- a/.github/actions/install/psydac-in-container/action.yml
+++ b/.github/actions/install/psydac-in-container/action.yml
@@ -1,5 +1,7 @@
 name: Install Psydac in Container
 
+description: 
+
 inputs:
   compile_language:
     required: true
@@ -19,8 +21,9 @@ runs:
       run: |
           ls / -a
           which python3
-          git clone https://github.com/struphy-hub/psydac-for-struphy.git
-          cd psydac-for-struphy
+          ls -a
+          git clone https://github.com/struphy-hub/feectools.git
+          cd feectools
           echo ${GIT_BRANCH_NAME}
           git checkout ${GIT_BRANCH_NAME}
           git pull

--- a/.github/actions/install/psydac-in-container/action.yml
+++ b/.github/actions/install/psydac-in-container/action.yml
@@ -22,10 +22,8 @@ runs:
           ls / -a
           which python3
           ls -a
-          mkdir for_cloning
-          cd for_cloning
-          git clone https://github.com/struphy-hub/feectools.git
-          cd feectools
+          git clone https://github.com/struphy-hub/feectools.git feectools-tmp
+          cd feectools-tmp
           echo ${GIT_BRANCH_NAME}
           git checkout ${GIT_BRANCH_NAME}
           git pull

--- a/.github/actions/install/psydac-req/action.yml
+++ b/.github/actions/install/psydac-req/action.yml
@@ -94,13 +94,13 @@ runs:
           path: "./petsc"
           key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
 
-    - if: steps.cache-petsc.outputs.cache-hit != 'true'
+    - if: steps.cache-petsc.outputs.cache-hit == ''
       name: Download a specific release of PETSc
       shell: bash
       run: |
           git clone --depth 1 --branch v3.23.3 https://gitlab.com/petsc/petsc.git
 
-    - if: steps.cache-petsc.outputs.cache-hit != 'true'
+    - if: steps.cache-petsc.outputs.cache-hit == ''
       name: Install PETSc with complex support
       working-directory: ./petsc
       shell: bash

--- a/.github/actions/install/psydac-req/action.yml
+++ b/.github/actions/install/psydac-req/action.yml
@@ -1,5 +1,7 @@
 name: Install prerequisites
 
+description: 
+
 runs:
   using: composite
   steps:

--- a/.github/actions/install/psydac-req/action.yml
+++ b/.github/actions/install/psydac-req/action.yml
@@ -92,7 +92,7 @@ runs:
           cache-name: cache-PETSc
       with:
           path: "./petsc"
-          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
+          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}-xxxxx
 
     - if: steps.cache-petsc.outputs.cache-hit != 'true'
       name: Download a specific release of PETSc

--- a/.github/actions/install/psydac-req/action.yml
+++ b/.github/actions/install/psydac-req/action.yml
@@ -92,7 +92,7 @@ runs:
           cache-name: cache-PETSc
       with:
           path: "./petsc"
-          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}-xxxxx
+          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
 
     - if: steps.cache-petsc.outputs.cache-hit != 'true'
       name: Download a specific release of PETSc

--- a/.github/actions/install/struphy-in-container/action.yml
+++ b/.github/actions/install/struphy-in-container/action.yml
@@ -1,5 +1,7 @@
 name: Install Struphy in Container
 
+description: 
+
 inputs:
   compile_language:
     required: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ Repository    = "https://github.com/struphy-hub/feectools"
 psydac-mesh = "feectools.cmd.mesh:main"
 psydac-accelerate = "feectools.accelerate.accelerate:main"
 
+[tool.setuptools.packages.find]
+include = ["feectools*"]
+exclude = ["*__psydac__*"]
+namespaces = false
+
 [tool.setuptools.package-data]
 "*" = ["*.txt"]
 feectools = ['accelerate/compile_psydac.mk']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "feectools"
-version         = "0.1.1"
+version         = "0.1.2"
 description     = "Slimmed-down fork of Psydac (https://github.com/pyccel/psydac) with less functionality and fewer dependencies."
 readme          = "README.md"
 requires-python = ">= 3.10"
@@ -53,17 +53,13 @@ mpi = [
 ]
 
 [project.urls]
-Homepage      = "https://github.com/struphy-hub/psydac-for-struphy"
-Documentation = "https://github.com/struphy-hub/psydac-for-struphy"
-Repository    = "https://github.com/struphy-hub/psydac-for-struphy"
+Homepage      = "https://github.com/struphy-hub/feectools"
+Documentation = "https://github.com/struphy-hub/feectools"
+Repository    = "https://github.com/struphy-hub/feectools"
 
 [project.scripts]
 psydac-mesh = "feectools.cmd.mesh:main"
-psydac-accelerate = "feectools.accelerate.accelerate:main"
-[tool.setuptools.packages.find]
-include = ["feectools*"]
-exclude = ["*__psydac__*"]
-namespaces = false
+psydac-accelerate = "feectools.accelerate.accelerate:main"q
 
 [tool.setuptools.package-data]
 "*" = ["*.txt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ Repository    = "https://github.com/struphy-hub/feectools"
 
 [project.scripts]
 psydac-mesh = "feectools.cmd.mesh:main"
-psydac-accelerate = "feectools.accelerate.accelerate:main"q
+psydac-accelerate = "feectools.accelerate.accelerate:main"
 
 [tool.setuptools.package-data]
 "*" = ["*.txt"]


### PR DESCRIPTION
Changed repo name to `feectools`.

I had to remove `--force-reinstall` and `--no-cache-dir` in the psydac install. Otherwise, the dependencies are not correctly resolved because a fresh psydac install does not respect any constraints coming from Struphy and its dependencies.